### PR TITLE
Fix ActionController::UnpermittedParameters

### DIFF
--- a/app/controllers/okuribito_rails/method_call_logs_controller.rb
+++ b/app/controllers/okuribito_rails/method_call_logs_controller.rb
@@ -4,14 +4,17 @@ module OkuribitoRails
   class MethodCallLogsController < ApplicationController
     def index
       @method_call_logs = MethodCallLog
-                          .search(method_call_log_params.presence || {})
+                          .search(search_params)
                           .page(params[Kaminari.config.param_name])
     end
 
     private
 
-    def method_call_log_params
-      params.permit(:class_name, :method_name)
+    def search_params
+      params.slice(
+        :class_name,
+        :method_name
+      ).presence || {}
     end
   end
 end

--- a/app/controllers/okuribito_rails/method_call_situations_controller.rb
+++ b/app/controllers/okuribito_rails/method_call_situations_controller.rb
@@ -4,15 +4,21 @@ module OkuribitoRails
   class MethodCallSituationsController < ApplicationController
     def index
       @method_call_situations = MethodCallSituation
-                                .search(method_call_situation_params.presence || {})
+                                .search(search_params)
                                 .page(params[Kaminari.config.param_name])
                                 .order(class_name: :asc, method_symbol: :asc, method_name: :asc)
     end
 
     private
 
-    def method_call_situation_params
-      params.permit(:class_name, :method_name, :x_days_passed, :uncalled_method, :called_method)
+    def search_params
+      params.slice(
+        :class_name,
+        :method_name,
+        :x_days_passed,
+        :uncalled_method,
+        :called_method
+      ).presence || {}
     end
   end
 end


### PR DESCRIPTION
Hi, @muramurasan 😃 

`ActionController::UnpermittedParameters` occurred when `params` contained pagenation parameter (`:page`).

Also, when searching, `:utf8` params may be included in `params`, so I modified to not use Strong Parameters.

Thanks.