### PR TITLE
Add a safe navigation to a chained destroy method to prevent an error

### DIFF
--- a/lib/okuribito_rails/regist_method.rb
+++ b/lib/okuribito_rails/regist_method.rb
@@ -40,7 +40,7 @@ module OkuribitoRails
 
     def destroy_method(method)
       a = method.split(/\s*(#|\.)\s*/)
-      MethodCallSituation.find_by(class_name: a[0], method_symbol: a[1], method_name: a[2]).destroy
+      MethodCallSituation.find_by(class_name: a[0], method_symbol: a[1], method_name: a[2])&.destroy
     end
   end
 end


### PR DESCRIPTION
Dear maintainers,
I faced an error that `destroy_method` tries to delete an unexisting method during initializing the app if DB and a yaml file aren't synchronized

This PR change would avoid that error