### PR TITLE
Add OkuribitoRails::TopController#show and set redirect to method_call_logs_path

### DIFF
--- a/app/controllers/okuribito_rails/top_controller.rb
+++ b/app/controllers/okuribito_rails/top_controller.rb
@@ -1,0 +1,9 @@
+require_dependency "okuribito_rails/application_controller"
+
+module OkuribitoRails
+  class TopController < ApplicationController
+    def show
+      redirect_to method_call_logs_path
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 OkuribitoRails::Engine.routes.draw do
   resources :method_call_logs, only: [:index]
   resources :method_call_situations, only: [:index]
+
+  root to: 'top#show'
 end


### PR DESCRIPTION
When I add the following code
```ruby
mount OkuribitoRails::Engine, at: "/okuribito_rails"
```
to `config/routes.rb`, I'd like to access to the top of `OkuribitoRails` by `okuribito_rails_path`.

In order to define `okuribito_rails_path`, I added `OkuribitoRails::TopController` and set `root to: 'top#show'`.

I do not know what should I add to view for `OkuribitoRails::TopController#show`, so I added redirect settings to `method_call_logs_path` in `OkuribitoRails::TopController#show`.
